### PR TITLE
Cherry picking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 cache: bundler
+addons:
+  postgresql: 9.3
 
 rvm:
   - 2.3.0

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ And reimplement only the following:
 * `db:seed`: Load `db/seeds.sql` into the database of your current environment.
 * `db:quality_check`: Load `db/quality_checks.sql` into the database of your current environment, if present.
 * `db:reset`: db:drop db:setup
-* `db:set_search_path`: read schema_search_path from database.yml and alter the associated database search_path
-* `db:setup`: db:create db:structure:load db:seed db:quality_check db:set_search_path
+* `db:settings`: Load the contents of `db/settings.sql` into the database of your current environment.
+* `db:setup`: db:create db:structure:load db:seed db:quality_check db:settings
 * `db:test:prepare`: RAILS_ENV=test db:reset db:migrate
 * `db:test:clone_structure`: RAILS_ENV=test db:reset db:migrate
 * `test:prepare`: db:test:prepare

--- a/features/commit.feature
+++ b/features/commit.feature
@@ -6,12 +6,14 @@ Feature: Commiting updated dumps to a project's repository
     And I successfully run `prodder init -c prodder.yml`
     And I successfully run `prodder dump -c prodder.yml`
 
-  Scenario: Structure, seed, and quality_checks files not yet tracked
+  Scenario: Structure, seed, quality_checks, permissions and settings files not yet tracked
     When I run `prodder commit -c prodder.yml`
     Then 1 commit by "prodder auto-commit" should be in the "blog" repository
     And the file "db/structure.sql" should now be tracked
     And the file "db/seeds.sql" should now be tracked
     And the file "db/quality_checks.sql" should now be tracked
+    And the file "db/permissions.sql" should now be tracked
+    And the file "db/settings.sql" should now be tracked
 
   Scenario: No changes to any file
     When I run `prodder commit -c prodder.yml`
@@ -30,6 +32,7 @@ Feature: Commiting updated dumps to a project's repository
     And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE linkbacks"
     And  the latest commit should not have changed "db/seeds.sql"
     And  the latest commit should not have changed "db/quality_checks.sql"
+    And  the latest commit should not have changed "db/settings.sql"
 
   Scenario: Changes only to the seed file
     When I run `prodder commit -c prodder.yml`
@@ -41,6 +44,7 @@ Feature: Commiting updated dumps to a project's repository
     And  the latest commit should have changed "db/seeds.sql" to contain "Marley"
     And  the latest commit should not have changed "db/structure.sql"
     And  the latest commit should not have changed "db/quality_checks.sql"
+    And  the latest commit should not have changed "db/settings.sql"
 
   Scenario: Changes to both
     When I run `prodder commit -c prodder.yml`
@@ -53,3 +57,28 @@ Feature: Commiting updated dumps to a project's repository
     And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE captchas"
     And  the latest commit should have changed "db/seeds.sql" to contain "Bob McBobbington"
     And  the latest commit should not have changed "db/quality_checks.sql"
+    And  the latest commit should not have changed "db/settings.sql"
+
+  Scenario: Changes only to permissions
+    When I run `prodder commit -c prodder.yml`
+    Then 1 commit by "prodder auto-commit" should be in the "blog" repository
+    When I create a new table "gotchas" in the "blog" database
+    When I grant all permissions on table "gotchas" in the "blog" database to "prodder"
+    And  I run `prodder dump -c prodder.yml`
+    And  I run `prodder commit -c prodder.yml`
+    And  2 commits by "prodder auto-commit" should be in the "blog" repository
+    And  the latest commit should have changed "db/permissions.sql" to contain "GRANT ALL ON TABLE gotchas TO prodder"
+    And  the latest commit should not have changed "db/seeds.sql"
+    And  the latest commit should not have changed "db/quality_checks.sql"
+
+  Scenario: Changes only to settings
+    When I run `prodder commit -c prodder.yml`
+    Then 1 commit by "prodder auto-commit" should be in the "blog" repository
+    When I add a custom parameter "enova.key" with value "value" in the "blog" project's database
+    And  I run `prodder dump -c prodder.yml`
+    And  I run `prodder commit -c prodder.yml`
+    And  2 commits by "prodder auto-commit" should be in the "blog" repository
+    And  the latest commit should have changed "db/settings.sql" to contain "ALTER DATABASE prodder__blog_prod SET  enova.key=value"
+    And  the latest commit should not have changed "db/seeds.sql"
+    And  the latest commit should not have changed "db/quality_checks.sql"
+    And  the latest commit should not have changed "db/permissions.sql"

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -3,7 +3,7 @@ Feature: prodder dump
   Background:
     Given a prodder config in "prodder.yml" with project: blog
 
-  Scenario: Happy path: dump structure.sql, listed seed tables, quality_checks.sql and permissions.sql
+  Scenario: Happy path: dump structure.sql, listed seed tables, quality_checks.sql, permissions.sql and settings.sql
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0
     And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE posts/
@@ -13,6 +13,7 @@ Feature: prodder dump
     And  the workspace file "blog/db/quality_checks.sql" should match /SET search_path/
     And  the workspace file "blog/db/quality_checks.sql" should match /CREATE TRIGGER /
     And  the workspace file "blog/db/permissions.sql" should match /GRANT /
+    And  the workspace file "blog/db/settings.sql" should match /ALTER DATABASE /
 
   Scenario: Include specified users, exclude other login roles from permissions dump
     When I run `prodder dump -c prodder.yml`
@@ -117,6 +118,11 @@ Feature: prodder dump
     When  I run `prodder dump -c prodder.yml`
     Then  the exit status should be 0
     And   the workspace file "blog/db/structure.sql" should not match /CREATE TABLE authors/
+
+  Scenario: Verify settings file contents
+    Given I add a custom parameter "c.p" with value "v" in the "blog" project's database
+    When  I run `prodder dump -c prodder.yml`
+    Then the workspace file "blog/db/settings.sql" should match /ALTER DATABASE prodder__blog_prod SET  c.p=v/
 
   Scenario: Exclude specified schemas from structure dump
     Given the prodder config in "prodder.yml" excludes the schema "ads" from the dump of "blog"

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -41,6 +41,11 @@ Feature: prodder dump
   #TODO: Not sure how to test this
   Scenario: Exhaustively test ACL
 
+  Scenario: Valid until option is quoted
+    When I run `prodder dump -c prodder.yml`
+    Then the exit status should be 0
+    And  the workspace file "blog/db/permissions.sql" should match /VALID UNTIL '.*'/
+
   Scenario: Exclude passwords from permissions dump
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0

--- a/features/step_definitions/prodder_steps.rb
+++ b/features/step_definitions/prodder_steps.rb
@@ -13,6 +13,10 @@ Given 'I add an index to table "$table" on column "$column" in the "$project" pr
   Prodder::PG.new.psql "prodder__#{project}_prod", "CREATE INDEX test_index ON #{table} (#{column});"
 end
 
+Given 'I add a custom parameter "$parameter" with value "$value" in the "$project" project\'s database' do |parameter, value, project|
+  Prodder::PG.new.psql "prodder__#{project}_prod", "ALTER DATABASE prodder__#{project}_prod SET #{parameter} = #{value};"
+end
+
 Given 'I add a foreign key from table "$table1" and column "$column1" to table "$table2" and column "$column2" in the "$project" project\'s database' do |table1, column1, table2, column2, project|
   Prodder::PG.new.psql "prodder__#{project}_prod", "ALTER TABLE #{table1} ADD CONSTRAINT fk_authors FOREIGN KEY (#{column1}) REFERENCES #{table2} (#{column2});"
 end
@@ -49,6 +53,11 @@ When 'I add a "$name" schema to the "$project" project\'s database' do |name, pr
   pg.psql "prodder__#{project}_prod", "CREATE SCHEMA #{name} AUTHORIZATION prodder CREATE TABLE #{name}.providers ( id SERIAL PRIMARY KEY );"
 end
 
+When 'I grant all permissions on table "$table" in the "$project" database to "$role"' do |table, project, role|
+  pg = Prodder::PG.new
+  pg.psql "prodder__#{project}_prod", "GRANT ALL ON #{table} TO #{role}"
+end
+
 Then 'the output should contain the example config contents' do
   assert_partial_output Prodder::Config.example_contents, all_output
 end
@@ -72,7 +81,7 @@ Given(/a prodder config in "([^"]*)" with projects?: (.*)/) do |filename, projec
       structure_file: db/structure.sql
       seed_file: db/seeds.sql
       quality_check_file: db/quality_checks.sql
-      permissions: 
+      permissions:
         file: db/permissions.sql
         included_users: prodder, include_this
       git:

--- a/features/support/prodder__blog_prod.sql
+++ b/features/support/prodder__blog_prod.sql
@@ -34,6 +34,42 @@ $$
 
 CREATE TRIGGER test_comments BEFORE UPDATE OR INSERT ON comments FOR EACH ROW EXECUTE PROCEDURE test();
 
+CREATE OR REPLACE FUNCTION create_role_if_not_exists(rolename VARCHAR)
+RETURNS VOID
+AS
+$create_role_if_not_exists$
+DECLARE
+BEGIN
+  IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_roles
+      WHERE  rolname = rolename) THEN
+    EXECUTE 'CREATE ROLE ' || quote_ident(rolename) || ' ;';
+  END IF;
+END;
+$create_role_if_not_exists$
+LANGUAGE PLPGSQL;
+
+SELECT create_role_if_not_exists('_90enva');
+SELECT create_role_if_not_exists('_91se');
+SELECT create_role_if_not_exists('_91qa');
+SELECT create_role_if_not_exists('_91b');
+SELECT create_role_if_not_exists('_92se');
+SELECT create_role_if_not_exists('_92qa');
+SELECT create_role_if_not_exists('_92b');
+SELECT create_role_if_not_exists('_93se');
+SELECT create_role_if_not_exists('_93qa');
+SELECT create_role_if_not_exists('_93b');
+SELECT create_role_if_not_exists('_94se');
+SELECT create_role_if_not_exists('_94qa');
+SELECT create_role_if_not_exists('_94b');
+SELECT create_role_if_not_exists('include_this');
+SELECT create_role_if_not_exists('exclude_this');
+SELECT create_role_if_not_exists('prodder__blog_prod:permissions_test:read_write');
+SELECT create_role_if_not_exists('prodder__blog_prod:permissions_test:read_only');
+SELECT create_role_if_not_exists('prodder__blog_prod:read_write');
+SELECT create_role_if_not_exists('prodder__blog_prod:read_only');
+
 GRANT "_90enva" TO "_91se";
 GRANT "_90enva" TO "_91qa";
 GRANT "_90enva" TO "_91b";
@@ -56,6 +92,7 @@ GRANT "prodder__blog_prod:permissions_test:read_only" TO exclude_this;
 
 GRANT "prodder__blog_prod:permissions_test:read_only" TO "prodder__blog_prod:read_only";
 GRANT "prodder__blog_prod:permissions_test:read_write" TO "prodder__blog_prod:read_write";
+ALTER ROLE "include_this" VALID UNTIL '2222-08-11 00:00:00-05';
 
 GRANT "prodder__blog_prod:read_only" TO prodder;
 

--- a/features/support/prodder__blog_prod.sql
+++ b/features/support/prodder__blog_prod.sql
@@ -1,3 +1,5 @@
+ALTER DATABASE prodder__blog_prod SET custom.parameter = 1;
+
 CREATE TABLE authors (
   author_id serial primary key,
   name text

--- a/lib/prodder/pg.rb
+++ b/lib/prodder/pg.rb
@@ -41,6 +41,31 @@ module Prodder
       run ['psql', db_name], sql
     end
 
+    def dump_settings(db_name, filename)
+      sql = <<-SQL
+        select unnest(setconfig)
+        from pg_catalog.pg_db_role_setting
+        join pg_database on pg_database.oid = setdatabase
+        -- 0 = default, for all users
+        where setrole = 0
+        and datname = '#{db_name}'
+      SQL
+
+      arguments = [
+        '-t',
+        '-c', sql
+      ]
+
+      run ['psql', *arguments.push(db_name)] do |out, err, success|
+        raise PGDumpError.new(err) if !success
+        File.open(filename, 'w') do |f|
+          out.each_line do |setting|
+            f.write "ALTER DATABASE #{db_name} SET #{setting}" unless setting.gsub(/\s+/, '').empty?
+          end
+        end
+      end
+    end
+
     def dump_structure(db_name, filename, options = {})
       arguments = [
         '--schema-only',

--- a/lib/prodder/pg.rb
+++ b/lib/prodder/pg.rb
@@ -223,7 +223,7 @@ module Prodder
           end
 
           tmp_sql << " CONNECTION LIMIT #{role['rolconnlimit']}" unless role['rolconnlimit'].eql?("-1")
-          tmp_sql << " VALID UNTIL #{role['rolvaliduntil']}" unless role['rolvaliduntil'].nil?
+          tmp_sql << " VALID UNTIL '#{role['rolvaliduntil']}'" unless role['rolvaliduntil'].nil?
           tmp_sql << ";\n"
           tmp_sql << "COMMENT ON ROLE \"#{role['rolname']}\" IS '#{role['rolcomment']}';\n" unless role['rolcomment'].nil?
           rolalter_sql << "SELECT * FROM alter_role('#{role['rolname']}', $$#{tmp_sql}$$);\n"

--- a/lib/prodder/project.rb
+++ b/lib/prodder/project.rb
@@ -31,6 +31,9 @@ module Prodder
       pg.dump_structure db_credentials['name'], structure_file_name,
                         exclude_tables: excluded_tables, exclude_schemas: excluded_schemas
 
+      FileUtils.mkdir_p File.dirname(settings_file_name)
+      pg.dump_settings db_credentials['name'], settings_file_name
+
       FileUtils.mkdir_p File.dirname(seed_file_name)
       pg.dump_tables db_credentials['name'], seed_tables, seed_file_name
 
@@ -50,7 +53,7 @@ module Prodder
 
       if dump_permissions?
         FileUtils.mkdir_p File.dirname(permissions_file_name)
-        pg.dump_permissions db_credentials['name'], permissions_file_name, included_users: included_users, 
+        pg.dump_permissions db_credentials['name'], permissions_file_name, included_users: included_users,
                             exclude_tables: excluded_tables, exclude_schemas: excluded_schemas
 
       end
@@ -61,6 +64,8 @@ module Prodder
       git.add structure_file_name
       git.add seed_file_name
       git.add quality_check_file_name if separate_quality_checks?
+      git.add permissions_file_name if dump_permissions?
+      git.add settings_file_name
       git.commit "Auto-commit by prodder", @defn['git']['author']
     end
 
@@ -97,6 +102,10 @@ module Prodder
       File.join workspace, @defn['structure_file']
     end
 
+    def settings_file_name
+      File.join workspace, 'db/settings.sql'
+    end
+
     def seed_file_name
       File.join workspace, @defn['seed_file']
     end
@@ -114,7 +123,7 @@ module Prodder
     end
 
     def dump_permissions?
-      @defn.key?('permissions') && permissions.key?('file') 
+      @defn.key?('permissions') && permissions.key?('file')
     end
 
     def excluded_schemas

--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end

--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.6.2"
+  VERSION = "1.7"
 end


### PR DESCRIPTION
1) Valid until timestamp was not quoted when being dumped, leads to errors while restoring - fixed
2) Dumps db settings, replaced set_search_path task with load settings task
3) Fixed bug where `db/permissions.sql` file was not automatically included in commits
4) Explicitly specified postgresql 9.3 in `.travis.yml`
