### PR TITLE
Bug fixes for dumping and restoring db_settings

### DIFF
--- a/features/dump.feature
+++ b/features/dump.feature
@@ -120,9 +120,14 @@ Feature: prodder dump
     And   the workspace file "blog/db/structure.sql" should not match /CREATE TABLE authors/
 
   Scenario: Verify settings file contents
-    Given I add a customer parameter "c.p" with value "v" in the "blog" project's database
+    Given I add a custom parameter "c.p" with value "v" in the "blog" project's database
     When  I run `prodder dump -c prodder.yml`
-    Then the workspace file "blog/db/settings.sql" should match /ALTER DATABASE prodder__blog_prod SET  c.p=v/
+    Then the workspace file "blog/db/settings.sql" should match /ALTER DATABASE :DBNAME SET  c.p=v;/
+
+  Scenario: Verify empty db setting is quoted
+    Given I add a custom parameter "empty.setting" with value "" in the "blog" project's database
+    When  I run `prodder dump -c prodder.yml`
+    Then the workspace file "blog/db/settings.sql" should match /ALTER DATABASE :DBNAME SET  empty.setting='';/
 
   Scenario: Exclude specified schemas from structure dump
     Given the prodder config in "prodder.yml" excludes the schema "ads" from the dump of "blog"

--- a/features/step_definitions/prodder_steps.rb
+++ b/features/step_definitions/prodder_steps.rb
@@ -13,8 +13,8 @@ Given 'I add an index to table "$table" on column "$column" in the "$project" pr
   Prodder::PG.new.psql "prodder__#{project}_prod", "CREATE INDEX test_index ON #{table} (#{column});"
 end
 
-Given 'I add a customer parameter "$parameter" with value "$value" in the "$project" project\'s database' do |parameter, value, project|
-  Prodder::PG.new.psql "prodder__#{project}_prod", "ALTER DATABASE prodder__#{project}_prod SET #{parameter} = #{value};"
+Given 'I add a custom parameter "$parameter" with value "$value" in the "$project" project\'s database' do |parameter, value, project|
+  Prodder::PG.new.psql "prodder__#{project}_prod", "ALTER DATABASE prodder__#{project}_prod SET #{parameter} = '#{value}';"
 end
 
 Given 'I add a foreign key from table "$table1" and column "$column1" to table "$table2" and column "$column2" in the "$project" project\'s database' do |table1, column1, table2, column2, project|

--- a/lib/prodder/pg.rb
+++ b/lib/prodder/pg.rb
@@ -52,6 +52,8 @@ module Prodder
       SQL
 
       arguments = [
+        '--host', credentials['host'],
+        '--username', credentials['user'],
         '-t',
         '-c', sql
       ]
@@ -60,7 +62,12 @@ module Prodder
         raise PGDumpError.new(err) if !success
         File.open(filename, 'w') do |f|
           out.each_line do |setting|
-            f.write "ALTER DATABASE #{db_name} SET #{setting}" unless setting.gsub(/\s+/, '').empty?
+            unless setting.gsub(/\s+/, '').empty?
+              setting.chomp!
+              setting += "''" if setting.match /.*=$/
+              # using the magic of psql variables through :DBNAME
+              f.puts "ALTER DATABASE :DBNAME SET #{setting};"
+            end
           end
         end
       end

--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.7"
+  VERSION = "1.7.1"
 end


### PR DESCRIPTION
1) Quotes empty values
2) Adds semicolons
3) Takes host and user credentials
4) Using `:DBNAME` psql application variable to infer database name in different environments
