### PR TITLE
Use PG instead of psql to dump settings

### DIFF
--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.7.2"
+  VERSION = "1.7.3"
 end


### PR DESCRIPTION
Fixes https://github.com/enova/prodder/issues/18

The current implementation dumps database settings by shelling out and running a query using the `psql` binary. There is no necessity to shell out and do this, when it can very well just be done through the proper means -> the `pg` gem.

```bash
clm-srangarajan:prodder(refactor_dumping_db_settings)$ psql -t -c "select unnest(setconfig) as config from pg_catalog.pg_db_role_setting join pg_database on pg_database.oid = setdatabase where setrole = 0 and datname = 'identity_development'"
 search_path=identity, public
```

However, as it turns out, this also causes a bug. If someone has a `psqlrc` or some equivalent file that sets options such as turning on timing by default for query execution, the timing makes its way into the output of the command too, like so:

```bash
clm-srangarajan:prodder(refactor_dumping_db_settings)$ /usr/local/pgsql/bin/psql -t -c "select unnest(setconfig) as config from pg_catalog.pg_db_role_setting join pg_database on pg_database.oid = setdatabase where setrole = 0 and datname = 'identity_development'" identity_development
Timing is on.
 search_path=identity, public

Time: 1.938 ms
```

There is a `psql -x` flag which would ignore such startup user configs from being loaded before the command is run, but to avoid such future problems, we resort to just running our query through `pg` over `libpq` which is a much more standard framework to stand on that hand-rolled shell scripts.