### PR TITLE
Run db:<tasks> in user contexts

### DIFF
--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.7.5"
+  VERSION = "1.7.6"
 end


### PR DESCRIPTION
All of the db:<task>s today are run by directly overwriting the rails configurations to set env variables for the psql commands.

Additionally, after certain tasks such as `db:settings` we need to refresh all connections to the database to feel the effect of the changes.

Killing two birds with one stone, this fixes both the issues by using the `as...` helper which hijacks the rails configs instead of overwriting them in place, while also forcing a reconnect after the operation is performed.