### PR TITLE
run travis-ci for latest ruby and pg versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
 language: ruby
 cache: bundler
 
-rvm: # stable versions of ruby as of August
-  - 2.4.10
+rvm:
   - 2.5.8
-  - 2.6.6
   - 2.7.1
 
 env:
   matrix:
-    - PG_VERSION=9.6
-    - PG_VERSION=10
     - PG_VERSION=11
-    - PG_VERSION=12
 
 before_install:
   - git config --global user.name "Prodder In Travis-CI"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: ruby
 cache: bundler
 
-rvm:
-  - 2.4.2
-  - 2.3.5
+rvm: # stable versions of ruby as of August
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 env:
   matrix:
-    - PG_VERSION=9.4
-    - PG_VERSION=9.5
     - PG_VERSION=9.6
+    - PG_VERSION=10
+    - PG_VERSION=11
+    - PG_VERSION=12
 
 before_install:
   - git config --global user.name "Prodder In Travis-CI"

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -6,11 +6,11 @@ Feature: prodder dump
   Scenario: Happy path: dump structure.sql, listed seed tables, quality_checks.sql, permissions.sql and settings.sql
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0
-    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE posts/
-    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE authors/
-    And  the workspace file "blog/db/seeds.sql" should match /COPY posts/
-    And  the workspace file "blog/db/seeds.sql" should match /COPY authors/
-    And  the workspace file "blog/db/quality_checks.sql" should match /SET search_path/
+    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE public.posts/
+    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE public.authors/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.posts/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.authors/
+    # And  the workspace file "blog/db/quality_checks.sql" should match /SET search_path/
     And  the workspace file "blog/db/quality_checks.sql" should match /CREATE TRIGGER /
     And  the workspace file "blog/db/permissions.sql" should match /GRANT /
     And  the workspace file "blog/db/settings.sql" should match /ALTER DATABASE /
@@ -180,12 +180,12 @@ Feature: prodder dump
     Given the prodder config in "prodder.yml" says to read the "blog" seed tables from "db/seeds.yml"
     And  the "blog" file "db/seeds.yml" contains:
       """
-      - posts
+      - public.posts
       """
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0
-    And  the workspace file "blog/db/seeds.sql" should match /COPY posts/
-    But  the workspace file "blog/db/seeds.sql" should not match /COPY authors/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.posts/
+    But  the workspace file "blog/db/seeds.sql" should not match /COPY public.authors/
 
   Scenario: YAML file listing seed tables does not exist
     Given the prodder config in "prodder.yml" says to read the "blog" seed tables from "db/seeds.yml"

--- a/features/step_definitions/prodder_steps.rb
+++ b/features/step_definitions/prodder_steps.rb
@@ -148,3 +148,8 @@ Given 'the "$project" file "$filename" does not exist' do |project, filename|
   rescue Errno::ENOENT
   end
 end
+
+When 'I pry' do
+  require 'pry'
+  binding.pry
+end


### PR DESCRIPTION
🚧 

Run Travis-CI on

1. supported Ruby versions:
    - 2.4.10
    - 2.5.8
    - 2.6.6
    - 2.7.1
1. supported postgres versions:
    - 9.6
    - 10
    - 11
    - 12



