### PR TITLE
remove search_path from dump quality checks and add rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.4.2
-  - 2.3.5
+  - 2.5.8
+  - 2.7.2
 
 env:
   matrix:
-    - PG_VERSION=9.4
-    - PG_VERSION=9.5
-    - PG_VERSION=9.6
+    - PG_VERSION=11
 
 before_install:
   - git config --global user.name "Prodder In Travis-CI"
   - git config --global user.email "prodder@example.com"
+  # install postgres
+  - sudo apt-get install postgresql-client-$PG_VERSION postgresql-server-dev-$PG_VERSION
   # setup pg_dump
+  - ls -al /usr/lib/postgresql/
   - sudo ln -sfn /usr/lib/postgresql/$PG_VERSION/bin/pg_dump /usr/bin/pg_dump
   # start up the specific version of PG
   - sudo -E sh -c 'service postgresql stop'

--- a/features/commit.feature
+++ b/features/commit.feature
@@ -29,7 +29,7 @@ Feature: Commiting updated dumps to a project's repository
     And  I run `prodder dump -c prodder.yml`
     And  I run `prodder commit -c prodder.yml`
     And  2 commits by "prodder auto-commit" should be in the "blog" repository
-    And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE linkbacks"
+    And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE public.linkbacks"
     And  the latest commit should not have changed "db/seeds.sql"
     And  the latest commit should not have changed "db/quality_checks.sql"
 
@@ -52,7 +52,7 @@ Feature: Commiting updated dumps to a project's repository
     And  I run `prodder dump -c prodder.yml`
     And  I run `prodder commit -c prodder.yml`
     Then 2 commits by "prodder auto-commit" should be in the "blog" repository
-    And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE captchas"
+    And  the latest commit should have changed "db/structure.sql" to contain "CREATE TABLE public.captchas"
     And  the latest commit should have changed "db/seeds.sql" to contain "Bob McBobbington"
     And  the latest commit should not have changed "db/quality_checks.sql"
 
@@ -64,6 +64,6 @@ Feature: Commiting updated dumps to a project's repository
     And  I run `prodder dump -c prodder.yml`
     And  I run `prodder commit -c prodder.yml`
     And  2 commits by "prodder auto-commit" should be in the "blog" repository
-    And  the latest commit should have changed "db/permissions.sql" to contain "GRANT ALL ON TABLE gotchas TO prodder"
+    And  the latest commit should have changed "db/permissions.sql" to contain "GRANT ALL ON TABLE public.gotchas TO prodder"
     And  the latest commit should not have changed "db/seeds.sql"
     And  the latest commit should not have changed "db/quality_checks.sql"

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -6,11 +6,10 @@ Feature: prodder dump
   Scenario: Happy path: dump structure.sql, listed seed tables, quality_checks.sql, permissions.sql and settings.sql
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0
-    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE posts/
-    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE authors/
-    And  the workspace file "blog/db/seeds.sql" should match /COPY posts/
-    And  the workspace file "blog/db/seeds.sql" should match /COPY authors/
-    And  the workspace file "blog/db/quality_checks.sql" should match /SET search_path/
+    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE public.posts/
+    And  the workspace file "blog/db/structure.sql" should match /CREATE TABLE public.authors/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.posts/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.authors/
     And  the workspace file "blog/db/quality_checks.sql" should match /CREATE TRIGGER /
     And  the workspace file "blog/db/permissions.sql" should match /GRANT /
     And  the workspace file "blog/db/settings.sql" should match /ALTER DATABASE /
@@ -184,8 +183,8 @@ Feature: prodder dump
       """
     When I run `prodder dump -c prodder.yml`
     Then the exit status should be 0
-    And  the workspace file "blog/db/seeds.sql" should match /COPY posts/
-    But  the workspace file "blog/db/seeds.sql" should not match /COPY authors/
+    And  the workspace file "blog/db/seeds.sql" should match /COPY public.posts/
+    But  the workspace file "blog/db/seeds.sql" should not match /COPY public.authors/
 
   Scenario: YAML file listing seed tables does not exist
     Given the prodder config in "prodder.yml" says to read the "blog" seed tables from "db/seeds.yml"

--- a/lib/prodder/pg.rb
+++ b/lib/prodder/pg.rb
@@ -125,7 +125,6 @@ module Prodder
     ACL_REVOKE = /^REVOKE /
     DEFAULT_PRIVILEGES = /^ALTER DEFAULT PRIVILEGES /
     SET_OBJECT_OWNERSHIP = /.* OWNER TO /
-    SEARCH_PATH = /SET search_path = .*/
 
     def dump_db_access_control(db_name, user_list, options)
       perm_out_sql = ""
@@ -153,8 +152,7 @@ module Prodder
           if line.match(ACL_GRANT)           ||
              line.match(ACL_REVOKE)          ||
              line.match(DEFAULT_PRIVILEGES)  ||
-             line.match(SET_OBJECT_OWNERSHIP)||
-             line.match(SEARCH_PATH)
+             line.match(SET_OBJECT_OWNERSHIP)
 
             unless irrelevant_login_roles.include?(line.match(/ (\S*);$/)[1])
               perm_out_sql << line

--- a/lib/prodder/prodder.rake
+++ b/lib/prodder/prodder.rake
@@ -362,7 +362,8 @@ namespace :db do
 
   def as(user, opts = {}, &block)
     if File.exist?('db/permissions.sql')
-      config, config_was = ActiveRecord::Base.configurations.deep_dup, ActiveRecord::Base.configurations.deep_dup
+      # `ActiveRecord::Base.configurations` in Rails 6 now returns an object instead of a hash
+      config, config_was = ActiveRecord::Base.configurations.deep_dup.to_h, ActiveRecord::Base.configurations.deep_dup
       in_env = Array(opts[:in]) || config.keys
       if config.all? { |env, config_hash| in_env.include?(env) ? config_hash[user] : true }
         disconnect

--- a/lib/prodder/project.rb
+++ b/lib/prodder/project.rb
@@ -45,11 +45,8 @@ module Prodder
         contents = File.readlines(structure_file_name)
         rgx = /^\-\- .* Type: INDEX; |^\-\- .* Type: TRIGGER; |^\-\- .* Type: FK CONSTRAINT; /
         structure, *quality = contents.slice_before(rgx).to_a
-        # the first search path setting for constraints gets left over
-        # in the structure, so we need to *attempt* to grab that
-        quality_checks = (structure.grep(/SET search_path/).last || '') + quality.join
 
-        File.open(quality_check_file_name, 'w') { |f| f.write(quality_checks) }
+        File.open(quality_check_file_name, 'w') { |f| f.write(quality.join) }
         File.open(structure_file_name, 'w') { |f| f.write(structure.join) }
       end
 

--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.7.6"
+  VERSION = "1.7.7"
 end


### PR DESCRIPTION
🍏 

# Problems

## 1. search_path
`SET search_path` in pg_dump has change since 2018 in one of the versions of PG 9.6.x
This removes checks for `SET search_path` from quality checks


## 2. Rails 6 support 
Running `bundle exec rake db:drop` fails with following error:
```
NotImplementedError: `ActiveRecord::Base.configurations` in Rails 6 now returns an object instead of a hash. The `all?` method is not supported. Please use `configs_for` or consult the documentation for supported methods.
```

### Full stack trace

```
bundle exec rake db:drop --trace
** Invoke db:drop (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:load_config
** Execute db:drop
rake aborted!
NotImplementedError: `ActiveRecord::Base.configurations` in Rails 6 now returns an object instead of a hash. The `all?` method is not supported. Please use `configs_for` or consult the documentation for supported methods.
/Users/mokpro/.gem/ruby/2.5.7/gems/activerecord-6.0.3.2/lib/active_record/database_configurations.rb:221:in `method_missing'
/Users/mokpro/.gem/ruby/2.5.7/gems/prodder-1.7.6/lib/prodder/prodder.rake:367:in `as'
/Users/mokpro/.gem/ruby/2.5.7/gems/prodder-1.7.6/lib/prodder/prodder.rake:157:in `block (2 levels) in <top (required)>'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:281:in `block in execute'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:281:in `each'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:281:in `execute'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/Users/mokpro/.rubies/ruby-2.5.7/lib/ruby/2.5.0/monitor.rb:235:in `mon_synchronize'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/task.rb:188:in `invoke'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:160:in `invoke_task'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:116:in `each'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:116:in `block in top_level'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:125:in `run_with_threads'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:110:in `top_level'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:83:in `block in run'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:186:in `standard_exception_handling'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/lib/rake/application.rb:80:in `run'
/Users/mokpro/.gem/ruby/2.5.7/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/mokpro/.gem/ruby/2.5.7/bin/rake:23:in `load'
/Users/mokpro/.gem/ruby/2.5.7/bin/rake:23:in `<top (required)>'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/Users/mokpro/.gem/ruby/2.5.7/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/Users/mokpro/.gem/ruby/2.5.7/bin/bundle:23:in `load'
/Users/mokpro/.gem/ruby/2.5.7/bin/bundle:23:in `<main>'
Tasks: TOP => db:drop
```