### PR TITLE
add support to rails 6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ doc/
 nc.yml
 prodder-workspace/
 features/support/blog.git
+Gemfile.lock
+*.gem
+*.gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,14 @@
 language: ruby
 cache: bundler
 
+services:
+  - postgresql
+
 rvm:
   - 2.5.8
   - 2.7.2
 
-env:
-  matrix:
-    - PG_VERSION=11
-
-before_install:
-  - git config --global user.name "Prodder In Travis-CI"
-  - git config --global user.email "prodder@example.com"
-  # install postgres
-  - sudo apt-get install postgresql-client-$PG_VERSION postgresql-server-dev-$PG_VERSION
-  # setup pg_dump
-  - ls -al /usr/lib/postgresql/
-  - sudo ln -sfn /usr/lib/postgresql/$PG_VERSION/bin/pg_dump /usr/bin/pg_dump
-  # start up the specific version of PG
-  - sudo -E sh -c 'service postgresql stop'
-  - sleep 5s
-  - sudo -E sh -c 'service postgresql start $PG_VERSION'
-  - psql -U postgres -d postgres -c 'select setting from pg_settings where name = $m$server_version$m$;'
-
 script:
-  - psql --version
-  - pg_lsclusters
-  - psql -U postgres -d postgres -c 'select 1;'
-  - ls -al `which pg_dump`
   - bundle exec rake spec
   - bundle exec rake cucumber
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'cocaine'
 gem 'benzo'
 
 group :development, :test do
+  gem 'activerecord', '~> 6.1'
   gem 'rake'
   gem 'pry'
   gem 'pry-remote'

--- a/lib/prodder/version.rb
+++ b/lib/prodder/version.rb
@@ -1,3 +1,3 @@
 module Prodder
-  VERSION = "1.7.7"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
🍏 

Add breaking changes to support rails 6.1. This is a major version tick to prodder since it's not compatible with rails 5.x or older.


## Changes in [ActiveRecord 6.0](https://guides.rubyonrails.org/6_0_release_notes.html#active-record)

1. Change `ActiveRecord::Base.configurations to return an object instead of a hash. ([Pull Request](https://github.com/rails/rails/pull/33637))
2. `configuration_hash` returns a hash with symbolized keys
## Changes in ActiveRecord 6.1
3. `to_h` is deprecated
```
DEPRECATION WARNING: to_h is deprecated and will be removed from Rails 6.2 (You can use `ActiveRecord::Base.configurations.configs_for(env_name: 'env', name: 'primary').configuration_hash` to get the configuration hashes.)
```


