### PR TITLE
Import set to prevent uninitialized constant errors

### DIFF
--- a/lib/prodder/pg.rb
+++ b/lib/prodder/pg.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'pg'
+require 'set'
 
 module Prodder
   class PG


### PR DESCRIPTION
Not sure how (or if) it worked in the past, but it's necessary to import `set` as it's not part of the core library ([read more](https://stackoverflow.com/questions/66677174/ruby-error-of-block-in-initialize-uninitialized-constant-but-running-well-wit)).