### PR TITLE
Add generated gem build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 tmp
+prodder-*


### PR DESCRIPTION
Ignore files generated by `gem build`, e.g.:

![image](https://github.com/user-attachments/assets/449d25ea-6072-42da-8027-03729ae27b2b)
